### PR TITLE
Enable export of unused definitions

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -32,7 +32,7 @@ class ConfigSchemaHandlerTypescriptDefinitionsPlugin {
      * format: false -> improves generation performances
      * ignoreMinAndMaxItems: true -> maxItems: 100 in provider.s3.corsConfiguration definition is generating 100 tuples
      */
-    const compiledDefinitions = await compile(normalizedSchema, 'AWS', { format: false, ignoreMinAndMaxItems: true })
+    const compiledDefinitions = await compile(normalizedSchema, 'AWS', { format: false, ignoreMinAndMaxItems: true, unreachableDefinitions: true })
     fs.writeFileSync('index.d.ts', compiledDefinitions)
   }
 }


### PR DESCRIPTION
Addresses: #9

This fix is only temporary. All blocks definied as JSON-schema definitions are now compiled in exported Typescript definitions with this fix. However, those sub-definition are not actually referenced within the main `AWS` export, they are duplicated.

This comes from actual `$ref` reference being resolved by JS during processing of https://github.com/serverless/typescript/blob/master/plugin.js#L29 implemented in order to un-sugar `const` keyword down to single-value `enum` keyword