### PR TITLE
Add nodejs14.x runtime

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -296,6 +296,7 @@ export type AwsLambdaRuntime =
   | "java8.al2"
   | "nodejs10.x"
   | "nodejs12.x"
+  | "nodejs14.x"
   | "provided"
   | "provided.al2"
   | "python2.7"


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/