### PR TITLE
Fix resources definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "url": "https://github.com/serverless/typescript/issues"
   },
   "homepage": "https://github.com/serverless/typescript#readme",
-  "dependencies": {},
   "devDependencies": {
     "@types/json-schema": "^7.0.6",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
@@ -35,7 +34,7 @@
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.0",
-    "json-schema-to-typescript": "^10.0.2",
+    "json-schema-to-typescript": "^10.1.3",
     "prettier": "^2.2.1",
     "serverless": "*",
     "typescript": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.0",
     "json-schema-to-typescript": "^10.1.3",
+    "lodash": "^4.17.21",
     "prettier": "^2.2.1",
     "serverless": "*",
     "typescript": "^4.0.5"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,7 @@
 import { compile } from "json-schema-to-typescript";
 import fs from "fs";
 import type { JSONSchema4 } from "json-schema";
+import * as _ from "lodash";
 
 interface Serverless {
   configSchemaHandler: {
@@ -12,7 +13,7 @@ class ConfigSchemaHandlerTypescriptDefinitionsPlugin {
   private schema: JSONSchema4;
 
   constructor(serverless: Serverless) {
-    this.schema = serverless.configSchemaHandler.schema;
+    this.schema = _.cloneDeep(serverless.configSchemaHandler.schema);
   }
 
   commands = {
@@ -28,44 +29,13 @@ class ConfigSchemaHandlerTypescriptDefinitionsPlugin {
 
   async generateSchema() {
     /**
-     * https://github.com/serverless/typescript/issues/4
-     * JSON Schema v6 `const` keyword converted to `enum`
-     */
-    const normalizedSchema = replaceAllConstForEnum(this.schema);
-
-    /**
      * ignoreMinAndMaxItems: true -> maxItems: 100 in provider.s3.corsConfiguration definition is generating 100 tuples
      */
-    const compiledDefinitions = await compile(normalizedSchema, "AWS", {
+    const compiledDefinitions = await compile(this.schema, "AWS", {
       ignoreMinAndMaxItems: true,
-      unreachableDefinitions: true,
     });
     fs.writeFileSync("index.d.ts", compiledDefinitions);
   }
 }
-
-const replaceAllConstForEnum = (schema: JSONSchema4): JSONSchema4 => {
-  if ("object" !== typeof schema) {
-    return schema;
-  }
-
-  return Object.fromEntries(
-    Object.entries(schema).map(([key, value]) => {
-      if (key === "const") {
-        return ["enum", [value]];
-      }
-
-      if (Array.isArray(value)) {
-        return [key, value.map(replaceAllConstForEnum)];
-      }
-
-      if ("object" === typeof value && value !== null) {
-        return [key, replaceAllConstForEnum(value)];
-      }
-
-      return [key, value];
-    })
-  );
-};
 
 module.exports = ConfigSchemaHandlerTypescriptDefinitionsPlugin;


### PR DESCRIPTION
- Updated `json-schema-to-typescript` version to handle  natively `const` keywork - https://github.com/bcherny/json-schema-to-typescript/issues/263
- Cloned serverless schema to prevent an issue where some part of the schema has been frozen by the framework while compiling require the schema to be updatable.