### PR TITLE
[draft] Add initial types to allow a basic AWS Step Functions definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1317,7 +1317,95 @@ export interface AWS {
           [k: string]: unknown;
         };
   };
+  stepFunctions?: {
+    stateMachines: {
+      [m: string]: {
+        name: string;
+        definition: {
+          StartAt: string;
+          States: States;
+        };
+      };
+    };
+  };
 }
+
+interface BaseTask {
+  Type: 'Task';
+  Resource: string;
+  Parameters?: {
+    [p: string]: string;
+  };
+  ResultPath: string | null;
+}
+
+interface Task extends BaseTask {
+  Next: string;
+}
+
+interface EndTask extends BaseTask {
+  End: true;
+}
+
+interface Branch {
+  StartAt: string;
+  States: States;
+}
+
+interface Parallel {
+  Type: 'Parallel';
+  Branches: Branch[];
+  Catch: Catch[];
+  End: boolean;
+}
+
+interface IsNull {
+  Variable: string;
+  IsNull: boolean;
+  Next?: string;
+}
+
+interface BooleanEquals {
+  Variable: string;
+  BooleanEquals: boolean;
+  Next?: string;
+}
+
+type Test = IsNull | BooleanEquals
+
+interface And {
+  And: Test[];
+  Next: string;
+}
+
+type Choice = And | Test;
+
+interface Catch {
+  ErrorEquals: string[];
+  Next: string;
+}
+
+interface Choices {
+  Type: 'Choice';
+  Choices: Choice[];
+  Default?: string;
+}
+
+interface Wait {
+  Type: 'Wait';
+  TimestampPath: string;
+  Next: string;
+}
+
+interface Fail {
+  Type: 'Fail';
+  Error?: string;
+}
+
+interface States {
+  [s: string]: Task | EndTask | Parallel | Choices | Wait | Fail;
+}
+
 export interface AwsCfImport {
   "Fn::ImportValue": unknown;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1334,7 +1334,7 @@ interface BaseTask {
   Type: 'Task';
   Resource: string;
   Parameters?: {
-    [p: string]: string;
+    [p: string]: any;
   };
   ResultPath: string | null;
 }
@@ -1352,11 +1352,19 @@ interface Branch {
   States: States;
 }
 
-interface Parallel {
+interface ParallelBase {
   Type: 'Parallel';
   Branches: Branch[];
-  Catch: Catch[];
-  End: boolean;
+  Retry?: Retry[];
+  Catch?: Catch[];
+}
+
+interface Parallel extends ParallelBase {
+  Next: string;
+}
+
+interface ParallelEnd extends ParallelBase {
+  End: true;
 }
 
 interface IsNull {
@@ -1380,8 +1388,16 @@ interface And {
 
 type Choice = And | Test;
 
+interface Retry {
+  ErrorEquals: string[];
+  IntervalSeconds?: number;
+  BackoffRate?: number;
+  MaxAttempts?: number;
+}
+
 interface Catch {
   ErrorEquals: string[];
+  ResultPath?: string | null;
   Next: string;
 }
 
@@ -1400,10 +1416,11 @@ interface Wait {
 interface Fail {
   Type: 'Fail';
   Error?: string;
+  Cause?: any;
 }
 
 interface States {
-  [s: string]: Task | EndTask | Parallel | Choices | Wait | Fail;
+  [s: string]: Task | EndTask | Parallel | ParallelEnd | Choices | Wait | Fail;
 }
 
 export interface AwsCfImport {


### PR DESCRIPTION
This PR aims to add definitions for the `serverless-step-functions` plugin which is the defacto way to use AWS Step Functions with Serverless Framework.

The definitions are currently very incomplete, so this will need further work before it can be merged.