### PR TITLE
Fixed type error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1307,17 +1307,16 @@ export interface AWS {
       [k: string]: unknown;
     };
     Resources?: {
-      "Fn::Transform"?: {
-        Name: string;
-        Parameters?: {
-          [k: string]: unknown;
-        };
-      };
       /**
        * This interface was referenced by `undefined`'s JSON-Schema definition
        * via the `patternProperty` "^[a-zA-Z0-9]{1,255}$".
        */
-      [k: string]: {
+      [k: string]: typeof k extends "Fn::Transform" ? {
+        Name: string;
+        Parameters?: {
+          [k: string]: unknown;
+        };
+      } : {
         Type: string;
         Properties?: {
           [k: string]: unknown;


### PR DESCRIPTION
Fixes the type error `Property '"Fn::Transform"' of type '{ Name: string; Parameters?: { [k: string]: unknown; }; }' is not assignable to 'string' index type '{ Type: string; Properties?: { [k: string]: unknown; }; CreationPolicy?: { [k: string]: unknown; }; DeletionPolicy?: string; DependsOn?: AwsResourceDependsOn; Metadata?: { [k: string]: unknown; }; UpdatePolicy?: { ...; }; UpdateReplacePolicy?: string; Condition?: string; }'.`