### PR TITLE
Add NodeJS 20.x Support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ export type AwsLambdaRuntime =
   | "nodejs14.x"
   | "nodejs16.x"
   | "nodejs18.x"
+  | "nodejs20.x"
   | "provided"
   | "provided.al2"
   | "python3.7"


### PR DESCRIPTION
Lambda now supports NodeJS 20.x

https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-node-js-20/