### PR TITLE
feat: update the aws lambda runtime

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,9 @@ export type AwsLambdaMemorySize = number;
 export type AwsLambdaRole = string | AwsCfSub | AwsCfImport | AwsCfGetAtt;
 export type AwsLambdaRuntime =
   | "dotnet6"
+  | "dotnet8"
   | "go1.x"
+  | "java21"
   | "java17"
   | "java11"
   | "java8"
@@ -66,6 +68,7 @@ export type AwsLambdaRuntime =
   | "nodejs16.x"
   | "nodejs18.x"
   | "nodejs20.x"
+  | "nodejs22.x"
   | "provided"
   | "provided.al2"
   | "provided.al2023"
@@ -74,8 +77,11 @@ export type AwsLambdaRuntime =
   | "python3.9"
   | "python3.10"
   | "python3.11"
+  | "python3.12"
+  | "python3.13"
   | "ruby2.7"
-  | "ruby3.2";
+  | "ruby3.2"
+  | "ruby3.3";
 export type AwsLambdaRuntimeManagement =
   | ("auto" | "onFunctionUpdate")
   | {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/typescript",
-  "version": "3.38.0",
+  "version": "3.39.0",
   "description": "Serverless typescript definitions",
   "main": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
The aws lambda runtimes are updated to the latest according to the [documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

Resolves: https://github.com/serverless/typescript/issues/90