### PR TITLE
feat: update the schema for serverless v4

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,6 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type AwsArnString = string;
 export type ErrorCode = string;
 export type AwsCfFunction =
   | AwsCfImport
@@ -17,6 +16,7 @@ export type AwsCfFunction =
   | AwsCfToJsonString;
 export type AwsCfInstruction = string | AwsCfFunction;
 export type AwsArn = AwsArnString | AwsCfFunction;
+export type AwsArnString = string;
 export type FunctionName = string;
 export type AwsSecretsManagerArnString = string;
 export type FilterPatterns = {
@@ -57,7 +57,9 @@ export type AwsLambdaMemorySize = number;
 export type AwsLambdaRole = string | AwsCfSub | AwsCfImport | AwsCfGetAtt;
 export type AwsLambdaRuntime =
   | "dotnet6"
+  | "dotnet8"
   | "go1.x"
+  | "java21"
   | "java17"
   | "java11"
   | "java8"
@@ -66,6 +68,7 @@ export type AwsLambdaRuntime =
   | "nodejs16.x"
   | "nodejs18.x"
   | "nodejs20.x"
+  | "nodejs22.x"
   | "provided"
   | "provided.al2"
   | "provided.al2023"
@@ -74,6 +77,8 @@ export type AwsLambdaRuntime =
   | "python3.9"
   | "python3.10"
   | "python3.11"
+  | "python3.12"
+  | "python3.13"
   | "ruby2.7"
   | "ruby3.2";
 export type AwsLambdaRuntimeManagement =
@@ -135,6 +140,18 @@ export type AwsCfArrayInstruction = AwsCfInstruction[] | AwsCfSplit;
 export type ServiceName = string;
 
 export interface AWS {
+  org?: string;
+  app?: string;
+  outputs?: {
+    [k: string]:
+      | string
+      | number
+      | boolean
+      | unknown[]
+      | {
+          [k: string]: unknown;
+        };
+  };
   configValidationMode?: "error" | "warn" | "off";
   console?:
     | boolean
@@ -142,17 +159,6 @@ export interface AWS {
         [k: string]: unknown;
       };
   custom?: {
-    enterprise?: {
-      collectApiGatewayLogs?: boolean;
-      collectLambdaLogs?: boolean;
-      compressLogs?: boolean;
-      disableAwsSpans?: boolean;
-      disableFrameworksInstrumentation?: boolean;
-      disableHttpSpans?: boolean;
-      logAccessIamRole?: AwsArnString;
-      logIngestMode?: "push" | "pull";
-      disableWrapping?: boolean;
-    };
     [k: string]: unknown;
   };
   dashboard?: {
@@ -160,6 +166,29 @@ export interface AWS {
   };
   deprecationNotificationMode?: "error" | "warn" | "warn:summary";
   disabledDeprecations?: "*" | ErrorCode[];
+  build?:
+    | string
+    | {
+        esbuild?:
+          | {
+              external?: string[];
+              exclude?: string[];
+              packages?: "external";
+              buildConcurrency?: number;
+              bundle?: boolean;
+              minify?: boolean;
+              sourcemap?:
+                | boolean
+                | {
+                    type?: "inline" | "linked" | "external";
+                    setNodeOptions?: boolean;
+                    [k: string]: unknown;
+                  };
+              [k: string]: unknown;
+            }
+          | boolean;
+        [k: string]: unknown;
+      };
   frameworkVersion?: string;
   functions?: {
     /**
@@ -314,6 +343,7 @@ export interface AWS {
                       };
                     };
                   };
+                  timeoutInMillis?: number;
                 };
           }
         | {
@@ -688,6 +718,7 @@ export interface AWS {
       layers?: AwsLambdaLayers;
       logRetentionInDays?: AwsLogRetentionInDays;
       logDataProtectionPolicy?: AwsLogDataProtectionPolicy;
+      logs?: AwsLambdaLoggingConfiguration;
       maximumEventAge?: number;
       maximumRetryAttempts?: number;
       memorySize?: AwsLambdaMemorySize;
@@ -703,6 +734,7 @@ export interface AWS {
       reservedConcurrency?: number | AwsCfFunction | AwsCfIf;
       role?: AwsLambdaRole;
       runtime?: AwsLambdaRuntime;
+      build?: string;
       runtimeManagement?: AwsLambdaRuntimeManagement;
       tags?: AwsResourceTags;
       timeout?: AwsLambdaTimeout;
@@ -730,6 +762,7 @@ export interface AWS {
       };
     };
   };
+  licenseKey?: string;
   package?: {
     artifact?: string;
     exclude?: string[];
@@ -745,6 +778,25 @@ export interface AWS {
      * via the `patternProperty` "^[a-zA-Z0-9-]+$".
      */
     [k: string]: {
+      [k: string]: unknown;
+    };
+  };
+  stages?: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-zA-Z0-9-]+$".
+     */
+    [k: string]: {
+      observability?:
+        | boolean
+        | ("axiom" | "dashboard")
+        | {
+            provider: "axiom" | "dashboard";
+            dataset?: string;
+          };
+      resolvers?: {
+        [k: string]: unknown;
+      };
       [k: string]: unknown;
     };
   };
@@ -824,6 +876,7 @@ export interface AWS {
       };
       shouldStartNameWithService?: boolean;
       stage?: string;
+      timeoutInMillis?: number;
       usagePlan?:
         | {
             quota?: {
@@ -974,8 +1027,10 @@ export interface AWS {
               buildArgs?: {
                 [k: string]: string;
               };
+              buildOptions?: string[];
               cacheFrom?: string[];
               platform?: string;
+              provenance?: string;
             }
           | string;
       };
@@ -987,6 +1042,7 @@ export interface AWS {
     logDataProtectionPolicy?: AwsLogDataProtectionPolicy;
     logs?: {
       frameworkLambda?: boolean;
+      lambda?: AwsLambdaLoggingConfiguration;
       httpApi?:
         | boolean
         | {
@@ -1053,6 +1109,7 @@ export interface AWS {
       | "me-central-1"
       | "me-south-1"
       | "sa-east-1";
+    resolver?: string;
     role?: AwsLambdaRole;
     rolePermissionsBoundary?: AwsArnString;
     rollbackConfiguration?: {
@@ -1064,6 +1121,7 @@ export interface AWS {
     };
     runtime?: AwsLambdaRuntime;
     runtimeManagement?: AwsLambdaRuntimeManagement;
+    build?: string;
     deploymentMethod?: "changesets" | "direct";
     s3?: {
       [k: string]: {
@@ -1342,6 +1400,11 @@ export interface AWS {
     websocketsDescription?: string;
   };
   service: ServiceName;
+  state?:
+    | {
+        resolver: string;
+      }
+    | string;
   useDotenv?: true;
   variablesResolutionMode?: "20210219" | "20210326";
   resources?: {
@@ -1437,18 +1500,6 @@ export interface AWS {
       retain?: boolean;
     };
   };
-  org?: string;
-  app?: string;
-  outputs?: {
-    [k: string]:
-      | string
-      | number
-      | boolean
-      | unknown[]
-      | {
-          [k: string]: unknown;
-        };
-  };
 }
 export interface AwsCfImport {
   "Fn::ImportValue": unknown;
@@ -1513,6 +1564,12 @@ export interface AwsLogDataProtectionPolicy {
   Description?: string;
   Version: string;
   Statement: unknown[];
+}
+export interface AwsLambdaLoggingConfiguration {
+  applicationLogLevel?: "DEBUG" | "ERROR" | "FATAL" | "INFO" | "TRACE" | "WARN";
+  logFormat?: "JSON" | "Text";
+  logGroup?: string;
+  systemLogLevel?: "DEBUG" | "INFO" | "WARN";
 }
 export interface AwsResourceTags {
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/typescript",
-  "version": "3.38.0",
+  "version": "4.4.18",
   "description": "Serverless typescript definitions",
   "main": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Using the the commands mentioned in github actions, the new schema for serverless v4 is generated.

Resolves: https://github.com/serverless/typescript/issues/89